### PR TITLE
Set lazy="false" in Department persistence configuration, which means…

### DIFF
--- a/src/main/resources/Department.hbm.xml
+++ b/src/main/resources/Department.hbm.xml
@@ -24,7 +24,7 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="by.academy.it.domain">
-    <class name="Department">
+    <class name="Department" lazy="false">
         <id name="id" type="integer">
             <generator class="increment"/>
         </id>


### PR DESCRIPTION
… that attempt to load department by not existing id will fail with ObjectNotFoundException